### PR TITLE
Add legacyBehavior prop to Next.js Link components

### DIFF
--- a/components/Editor/PostEditorPage.js
+++ b/components/Editor/PostEditorPage.js
@@ -255,7 +255,7 @@ const PostEditorPage = (props) => {
                 <Grid container>
                     {editorMode && (
                         <Grid item xs={12}>
-                            <Link href={`/` + posts.slug}>
+                            <Link href={`/` + posts.slug} legacyBehavior>
                                 <a>
                                     <p>Back to Post</p>
                                 </a>

--- a/components/article/PostsTable.js
+++ b/components/article/PostsTable.js
@@ -337,7 +337,7 @@ function PostsTable(props) {
                             .map((row) => (
                                 <TableRow key={row.slug}>
                                     <TableCell>
-                                        <Link href={`/${row.slug}`}>
+                                        <Link href={`/${row.slug}`} legacyBehavior>
                                             <a>{row.title}</a>
                                         </Link>
                                     </TableCell>

--- a/components/user/ProfileLayout.js
+++ b/components/user/ProfileLayout.js
@@ -86,7 +86,7 @@ const ProfileLayout = (props) => {
                 )}
                 {dashboardPermission && (
                     <Grid item>
-                        <Link href="/dashboard">
+                        <Link href="/dashboard" legacyBehavior>
                             <a>
                                 <Button variant="contained" disableElevation>
                                     Creator Dashboard
@@ -97,7 +97,7 @@ const ProfileLayout = (props) => {
                 )}
                 {isOwner && (
                     <Grid item>
-                        <Link href="/profile/edit">
+                        <Link href="/profile/edit" legacyBehavior>
                             <a>
                                 <Button
                                     variant="contained"
@@ -137,6 +137,7 @@ const ProfileLayout = (props) => {
                                     ? `/user/${user?.username}`
                                     : `/user/${user?.username}`
                             }
+                            legacyBehavior
                         >
                             <Tooltip title="Visit public profile page">
                                 

--- a/pages/404.js
+++ b/pages/404.js
@@ -45,7 +45,7 @@ const NotFound = () => {
             </Box>
             <p>
                 Going back to the{" "}
-                <Link href="/">
+                <Link href="/" legacyBehavior>
                     <a>homepage</a>
                 </Link>{" "}
                 in {seconds}...

--- a/pages/[articlePage].js
+++ b/pages/[articlePage].js
@@ -235,6 +235,7 @@ const Article = ({
                                         contributor?.username ||
                                         author?.username
                                     }`}
+                                    legacyBehavior
                                 >
                                     <Tooltip
                                         title={
@@ -293,6 +294,7 @@ const Article = ({
                                             contributor?.username ||
                                             author?.username
                                         }`}
+                                        legacyBehavior
                                     >
                                         <a>
                                             <p
@@ -365,7 +367,7 @@ const Article = ({
                                     display: { xs: "flex", sm: "none" },
                                 }}
                             >
-                                <Link href={`/edit/` + posts._id}>
+                                <Link href={`/edit/` + posts._id} legacyBehavior>
                                     <a>
                                         <Button
                                             variant="contained"
@@ -435,7 +437,7 @@ const Article = ({
                                         display: { xs: "none", sm: "flex" },
                                     }}
                                 >
-                                    <Link href={`/edit/` + posts._id}>
+                                    <Link href={`/edit/` + posts._id} legacyBehavior>
                                         <a>
                                             <p
                                                 className="secondary"

--- a/pages/about.js
+++ b/pages/about.js
@@ -142,6 +142,7 @@ const About = () => {
                                 "/team/" +
                                 member.name.replace(/\s+/g, "-").toLowerCase()
                             }
+                            legacyBehavior
                         >
                             <a>
                                 <Image
@@ -172,6 +173,7 @@ const About = () => {
                                         .replace(/\s+/g, "-")
                                         .toLowerCase()
                                 }
+                                legacyBehavior
                             >
                                 <a>
                                     <h4
@@ -312,6 +314,7 @@ const About = () => {
                                 "/team/" +
                                 member.name.replace(/\s+/g, "-").toLowerCase()
                             }
+                            legacyBehavior
                         >
                             <a>
                                 <Image
@@ -343,6 +346,7 @@ const About = () => {
                                         .replace(/\s+/g, "-")
                                         .toLowerCase()
                                 }
+                                legacyBehavior
                             >
                                 <a>
                                     <h4

--- a/pages/drafts.js
+++ b/pages/drafts.js
@@ -97,7 +97,7 @@ function DraftsPanel({ posts, authors, contributors }) {
                     </p>
                 </Grid>
                 <Grid item>
-                    <Link href="/dashboard">
+                    <Link href="/dashboard" legacyBehavior>
                         <a>
                             <Button
                                 color="secondary"

--- a/pages/profile/edit.js
+++ b/pages/profile/edit.js
@@ -79,7 +79,7 @@ const Profile = () => {
                         <Grid container direction="column" spacing={4}>
                             <Grid item>
                                 <h1>Settings</h1>
-                                <Link href="/profile">
+                                <Link href="/profile" legacyBehavior>
                                     <a>
                                         <p>Back to Profile</p>
                                     </a>

--- a/pages/resources.js
+++ b/pages/resources.js
@@ -30,7 +30,7 @@ export default function Resources() {
               Join Melissa Henderson as she discusses fashion tech applications and products with leading voices in the web3 community.
             </p>
             {/* Link to YouTube video added here */}
-            <Link href={youtubeVideoUrl}>
+            <Link href={youtubeVideoUrl} legacyBehavior>
               <a>
                 Watch Video
               </a>


### PR DESCRIPTION
## Summary
This PR adds the `legacyBehavior` prop to all Next.js `<Link>` components throughout the application. This change ensures compatibility with Next.js 13+ while maintaining the current behavior of wrapping child elements with anchor tags.

## Changes Made
- Added `legacyBehavior` prop to 16 `<Link>` components across multiple files
- Affected components:
  - `components/Editor/PostEditorPage.js` - Back to Post link
  - `components/article/PostsTable.js` - Post title links in table
  - `components/user/ProfileLayout.js` - Dashboard and profile edit links
  - `pages/404.js` - Homepage link
  - `pages/[articlePage].js` - Author/contributor profile links and edit links
  - `pages/about.js` - Team member profile links
  - `pages/drafts.js` - Dashboard link
  - `pages/profile/edit.js` - Back to Profile link
  - `pages/resources.js` - YouTube video link

## Implementation Details
The `legacyBehavior` prop tells Next.js to use the legacy Link behavior where the component requires an `<a>` tag as a child. This is necessary because the codebase currently wraps all Link children with explicit `<a>` elements. Without this prop, Next.js 13+ will issue warnings or errors about improper Link usage.

This change maintains backward compatibility and allows the application to work correctly with newer versions of Next.js while keeping the existing DOM structure intact.

https://claude.ai/code/session_01QHjoGNzWprV8tE1Qd2Zf8e